### PR TITLE
fix: footer スマホで崩れる

### DIFF
--- a/src/assets/global.pcss
+++ b/src/assets/global.pcss
@@ -105,7 +105,10 @@ footer {
 	p {
 		display: flex;
 		align-items: center;
+		justify-content: center;
 		gap: .5em;
+		white-space: nowrap;
+		flex-wrap: wrap;
 
 		a {
 			display: inline-flex;


### PR DESCRIPTION
## Overview

幅が小さいときは改行するようにした

## Testing

- [x] PC, SP 見た目確認

## Screenshots or Videos

<img width="373" alt="image" src="https://github.com/user-attachments/assets/be7ca13d-fec1-4d39-9bf1-bee7e88b88cf" />
