### PR TITLE
feat: List 表示オプションの追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -20,7 +20,7 @@ GitHub Pages などで公開する静的なページの閲覧に便利です。
 | --- | --- |
 | ![Light Theme Demo](https://github.com/user-attachments/assets/12db5a6a-4b25-45dd-aab6-eac3163e4d10) | ![Dark Theme Demo](https://github.com/user-attachments/assets/db7691a9-8e37-47ac-920f-aa0b4e634b99) |
 
-この Action を使って生成した実際のデモページは GitHub Pages で公開しています。
+この Action を使って生成した実際のデモページは GitHub Pages で公開しています。  
 https://ykicchan.github.io/generate-directory-listing-action/
 
 ## 使い方
@@ -67,6 +67,24 @@ uses: yKicchan/generate-directory-listing-action@v1
     ignore: "**/*.map"
 ```
 
+### 表示形式を変更する
+
+`viewType` オプションを利用することで、表示形式を変更することができます。  
+現在は `table` と `list` が利用可能で、デフォルトは `table` です。  
+下記は `list` での表示例です。
+
+```yml
+- name: Generate Directory listing
+  uses: yKicchan/generate-directory-listing-action@v1
+  with:
+    target: dist
+    viewType: "list"
+```
+
+| Light Theme | Dark Theme |
+| --- | --- |
+| ![light](https://github.com/user-attachments/assets/7046a514-17d9-49e0-b090-8fa462256088) | ![dark](https://github.com/user-attachments/assets/6b952edd-8d82-4dee-a290-19da264580eb) |
+
 ### 見た目をカスタマイズする
 
 追加の CSS を読み込ませて、出力する `index.html` の見た目をカスタマイズすることができます。
@@ -92,8 +110,9 @@ uses: yKicchan/generate-directory-listing-action@v1
 
 | キーワード | 型 | 必須 | デフォルト値 | 説明 |
 | --- | --- | --- | --- | --- |
-| target | string | yes | - | 探索可能にしたいターゲットディレクトリ |
-| ignore | string | no | - | 探索から排除したい glob パターン、カンマ区切りで複数指定が可能 |
-| showHiddenFiles | boolean | no | false | 隠しファイルを表示するかどうか |
-| theme | string | no | - | 生成される `index.html` を 拡張する CSS スタイル<br>`target` ディレクトリからの相対パスで指定する |
-| override | boolean | no | false | すでに `index.html` が存在する時に上書きするかどうか |
+| `target` | string | yes | - | 探索可能にしたいターゲットディレクトリ |
+| `viewType` | string | no | `table` | 表示形式を指定する<br>現在は `table` と `list` が利用可能 |
+| `ignore` | string | no | - | 探索から排除したい glob パターン、カンマ区切りで複数指定が可能 |
+| `showHiddenFiles` | boolean | no | `false` | 隠しファイルを表示するかどうか |
+| `theme` | string | no | - | 生成される `index.html` を 拡張する CSS スタイル<br>`target` ディレクトリからの相対パスで指定する |
+| `override` | boolean | no | `false` | すでに `index.html` が存在する時に上書きするかどうか |

--- a/README.md
+++ b/README.md
@@ -68,6 +68,24 @@ By using the `ignore` option, you can exclude files that match specific patterns
     ignore: "**/*.map"
 ```
 
+### Changing the Display Format
+
+You can change the display format using the `viewType` option.
+Currently, `table` and `list` are available, with the default being `table`.
+Below is an example of the `list` display.
+
+```yml
+- name: Generate Directory listing
+  uses: yKicchan/generate-directory-listing-action@v1
+  with:
+    target: dist
+    viewType: "list"
+```
+
+| Light Theme | Dark Theme |
+| --- | --- |
+| ![light](https://github.com/user-attachments/assets/7046a514-17d9-49e0-b090-8fa462256088) | ![dark](https://github.com/user-attachments/assets/6b952edd-8d82-4dee-a290-19da264580eb) |
+
 ### Customize Appearance
 
 You can load additional CSS to customize the appearance of the generated `index.html`.
@@ -93,8 +111,9 @@ For detailed specifications, check [action.yml](./action.yml).
 
 | Key | Type | Required | Default Value | Description |
 | --- | --- | --- | --- | --- |
-| target | string | yes | - | The target directory to make browsable |
-| ignore | string | no | - | Glob patterns to exclude from the search. Multiple patterns can be specified using commas. |
-| showHiddenFiles | boolean | no | false | Whether to display hidden files |
-| theme | string | no | - | CSS styles to enhance the generated `index.html`. Specify the path relative to the `target` directory. |
-| override | boolean | no | false | Whether to overwrite an existing `index.html` |
+| `target` | string | yes | - | The target directory to make browsable |
+| `viewType` | string | no | `"table"` | Specifies the display format.<br>Currently, `table` and `list` are available options. |
+| `ignore` | string | no | - | Glob patterns to exclude from the search. Multiple patterns can be specified using commas. |
+| `showHiddenFiles` | boolean | no | `false` | Whether to display hidden files |
+| `theme` | string | no | - | CSS styles to enhance the generated `index.html`. Specify the path relative to the `target` directory. |
+| `override` | boolean | no | `false` | Whether to overwrite an existing `index.html` |

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,12 @@ inputs:
   target:
     description: 'Path to target directory.'
     required: true
+  viewType:
+    description: |
+      View type of the directory listing.
+      Available options: `table`, `list`.
+    required: false
+    default: 'table'
   ignore:
     description: |
       Pattern to ignore files or directories.

--- a/src/app/contents/index.test.tsx
+++ b/src/app/contents/index.test.tsx
@@ -1,11 +1,10 @@
 import { render } from "@testing-library/preact";
-import type { Path } from "glob";
 import { ViewTypes } from "../../utils/view-types";
 import { Contents, type P } from "./index";
 
 describe("Contents", () => {
-	const setup = ({ files, viewType }: Partial<P> = {}) =>
-		render(<Contents files={files ?? []} viewType={viewType ?? ViewTypes.Table} />);
+	const setup = (props: Partial<P> = {}) =>
+		render(<Contents {...{ files: [], isRoot: true, viewType: ViewTypes.Table, ...props }} />);
 
 	it("contents が表示される", () => {
 		const { getByRole } = setup();

--- a/src/app/contents/index.tsx
+++ b/src/app/contents/index.tsx
@@ -1,23 +1,32 @@
+import type { Path } from "glob";
 import { ViewTypes } from "../../utils/view-types";
-import { Table, type P as TableProps } from "../table";
+import { List } from "./list";
+import { Table } from "./table";
 
-export type P = TableProps & {
+export type P = ContentProps & {
 	viewType: ViewTypes;
+};
+
+export type ContentProps = {
+	files: Path[];
+	isRoot: boolean;
 };
 
 export function Contents(props: P) {
 	return (
 		<main>
-			<SwitchView {...props} />
+			<Switcher {...props} />
 		</main>
 	);
 }
 
-function SwitchView({ viewType, ...tableProps }: P) {
+function Switcher({ viewType, ...contentProps }: P) {
 	switch (viewType) {
 		case ViewTypes.Table:
-			return <Table {...tableProps} />;
+			return <Table {...contentProps} />;
+		case ViewTypes.List:
+			return <List {...contentProps} />;
 		default:
-			return <Table {...tableProps} />;
+			return <Table {...contentProps} />;
 	}
 }

--- a/src/app/contents/list/index.test.tsx
+++ b/src/app/contents/list/index.test.tsx
@@ -1,17 +1,18 @@
 import fs from "node:fs";
 import { render, screen, within } from "@testing-library/preact";
 import type { Path } from "glob";
-import { beforeEach, describe, expect } from "vitest";
-import { type P, Table } from "./index";
+import { beforeEach, expect } from "vitest";
+import type { ContentProps } from "../index";
+import { List } from "./index";
 
 const mockStatSync = vi.spyOn(fs, "statSync");
 
-describe("Table", () => {
+describe("List", () => {
 	beforeEach(() => {
 		mockStatSync.mockClear();
 	});
 
-	const setup = ({ files = [], isRoot = true }: Partial<P> = {}, stats: Partial<fs.Stats> = {}) => {
+	const setup = ({ files = [], isRoot = true }: Partial<ContentProps> = {}, stats: Partial<fs.Stats> = {}) => {
 		mockStatSync.mockReturnValue({
 			isFile: () => true,
 			isDirectory: () => false,
@@ -20,84 +21,60 @@ describe("Table", () => {
 			...stats,
 		} as fs.Stats);
 
-		return render(<Table files={files} isRoot={isRoot} />);
+		return render(<List files={files} isRoot={isRoot} />);
 	};
 
 	describe("アイテムがファイルの時", () => {
 		beforeEach(() => {
 			const files = [
-				{ name: "file1.txt", fullpath: () => "file1.txt" },
-				{ name: "file2.png", fullpath: () => "file2.png" },
+				{ name: "file1.txt", fullpath: () => "file1.txt", isDirectory: () => false },
+				{ name: "file2.png", fullpath: () => "file2.png", isDirectory: () => false },
 			] as Path[];
 
 			setup({ files });
 		});
 
-		it("table が表示される", () => {
-			const table = screen.getByRole("table");
-			expect(table).toBeVisible();
-		});
-
-		it("table header が表示される", () => {
-			const rows = screen.getAllByRole("row");
-			// rows + header = 3
-			expect(rows).toHaveLength(3);
-
-			const header = rows[0];
-			expect(header).toBeVisible();
-			expect(header).toHaveTextContent("Name");
-			expect(header).toHaveTextContent("Size");
-			expect(header).toHaveTextContent("Last Modified");
+		it("ul が表示される", () => {
+			const ul = screen.getByRole("list");
+			expect(ul).toBeVisible();
 		});
 
 		it("1つめのファイルが表示される", () => {
-			const firstItem = screen.getAllByRole("row")[1];
+			const firstItem = screen.getAllByRole("listitem")[0];
 			expect(firstItem).toBeVisible();
 			expect(firstItem).toHaveAttribute("data-name", "file1.txt");
 			expect(firstItem).toHaveAttribute("data-type", "txt");
 			expect(within(firstItem).getByRole("link")).toHaveAttribute("href", "file1.txt");
-			expect(within(firstItem).getByText("1KB")).toBeVisible();
-			expect(within(firstItem).getByText("1/1/2000, 12:00:00 AM")).toBeVisible();
 		});
 
 		it("2つめのファイルが表示される", () => {
-			const secondItem = screen.getAllByRole("row")[2];
+			const secondItem = screen.getAllByRole("listitem")[1];
 			expect(secondItem).toBeVisible();
 			expect(secondItem).toHaveAttribute("data-name", "file2.png");
 			expect(secondItem).toHaveAttribute("data-type", "png");
 			expect(within(secondItem).getByRole("link")).toHaveAttribute("href", "file2.png");
-			expect(within(secondItem).getByText("1KB")).toBeVisible();
-			expect(within(secondItem).getByText("1/1/2000, 12:00:00 AM")).toBeVisible();
 		});
 	});
 
 	it("アイテムがディレクトリのとき、href と type がディレクトリ用になる", () => {
-		const files = [{ name: "dir", fullpath: () => "dir" }] as Path[];
-		const { getAllByRole } = setup(
-			{ files },
-			{
-				isFile: () => false,
-				isDirectory: () => true,
-			},
-		);
+		const files = [{ name: "dir", fullpath: () => "dir1", isDirectory: () => true }] as Path[];
 
-		const dir = getAllByRole("row")[1];
+		const { getByRole } = setup({ files });
+
+		const dir = getByRole("listitem");
 		expect(dir).toHaveAttribute("data-type", "dir");
 		expect(within(dir).getByRole("link")).toHaveAttribute("href", "dir/");
 	});
 
 	it("isRoot が true のとき、親ディレクトリへのリンクが表示されない", () => {
-		const { getAllByRole } = setup({ isRoot: true });
-
-		const rows = getAllByRole("row");
-		// header only
-		expect(rows).toHaveLength(1);
+		const { queryByRole } = setup({ isRoot: true });
+		expect(queryByRole("listitem")).toBeNull();
 	});
 
 	it("isRoot が false のとき、親ディレクトリへのリンクが表示される", () => {
-		const { getAllByRole } = setup({ isRoot: false });
-
-		const parent = getAllByRole("row")[1];
+		const { getByRole } = setup({ isRoot: false });
+		const parent = getByRole("listitem");
+		expect(parent).toHaveAttribute("data-name", "..");
 		expect(parent).toHaveAttribute("data-type", "parent");
 		expect(within(parent).getByRole("link")).toHaveAttribute("href", "../");
 	});

--- a/src/app/contents/list/index.tsx
+++ b/src/app/contents/list/index.tsx
@@ -1,0 +1,29 @@
+import * as core from "@actions/core";
+import type { ContentProps } from "../index";
+import { getExt, getHref } from "../shared/helper";
+
+export function List({ files, isRoot }: ContentProps) {
+	core.debug(`- Generated list: ${files.map((path) => path.name).join(", ")}`);
+	return (
+		<ul>
+			{!isRoot && <ListRow href={"../"} name=".." dataAttr={{ "data-type": "parent" }} />}
+			{files.map((path) => (
+				<ListRow key={path.name} dataAttr={{ "data-type": getExt(path) }} href={getHref(path)} name={path.name} />
+			))}
+		</ul>
+	);
+}
+
+interface ListRowProps {
+	href: string;
+	name: string;
+	dataAttr?: Record<`data-${string}`, string>;
+}
+
+function ListRow({ href, name, dataAttr = {} }: ListRowProps) {
+	return (
+		<li data-name={name} {...dataAttr}>
+			<a href={href}>{name}</a>
+		</li>
+	);
+}

--- a/src/app/contents/shared/helper.test.ts
+++ b/src/app/contents/shared/helper.test.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs";
+import type { Path } from "glob";
+import { describe } from "vitest";
+import * as dirs from "../../../utils/directories";
+import { getExt, getHref, getLastModified, getSize } from "./helper";
+
+describe("getHref", () => {
+	it("ディレクトリの時、href がディレクトリ用になる", () => {
+		const path = { name: "dir", isDirectory: () => true } as Path;
+		expect(getHref(path)).toBe("dir/");
+	});
+
+	it("ファイルの時、href がファイル用になる", () => {
+		const path = { name: "file.txt", isDirectory: () => false } as Path;
+		expect(getHref(path)).toBe("file.txt");
+	});
+});
+
+describe("getExt", () => {
+	it("ディレクトリの時、type がディレクトリ用になる", () => {
+		const path = { name: "dir", isDirectory: () => true } as Path;
+		expect(getExt(path)).toBe("dir");
+	});
+
+	it("ファイルの時、type が拡張子になる", () => {
+		const path = { name: "file.txt", isDirectory: () => false } as Path;
+		expect(getExt(path)).toBe("txt");
+	});
+});
+
+describe("getSize", () => {
+	it("ファイルの時、ファイルサイズが返される", () => {
+		const path = { name: "file.txt", fullpath: () => "file.txt" } as Path;
+		const file = { isFile: () => true, size: 1024 } as fs.Stats;
+		vi.spyOn(fs, "statSync").mockReturnValue(file);
+
+		expect(getSize(path)).toBe("1KB");
+	});
+
+	it("ディレクトリの時、ディレクトリサイズが返される", () => {
+		const path = { name: "dir", fullpath: () => "dir" } as Path;
+		const file = { isFile: () => false, isDirectory: () => true } as fs.Stats;
+		vi.spyOn(fs, "statSync").mockReturnValue(file);
+		vi.spyOn(dirs, "getDirSize").mockReturnValue(0);
+
+		expect(getSize(path)).toBe("0B");
+	});
+});
+
+describe("getLastModified", () => {
+	it("最終更新日時が返される", () => {
+		const path = { name: "file.txt", fullpath: () => "file.txt" } as Path;
+		const file = { mtime: new Date("2000-01-01 00:00:00") } as fs.Stats;
+		vi.spyOn(fs, "statSync").mockReturnValue(file);
+
+		expect(getLastModified(path)).toBe("1/1/2000, 12:00:00 AM");
+	});
+});

--- a/src/app/contents/shared/helper.ts
+++ b/src/app/contents/shared/helper.ts
@@ -1,0 +1,23 @@
+import fs from "node:fs";
+import bytes from "bytes";
+import type { Path } from "glob";
+import { getDirSize } from "../../../utils/directories";
+
+export function getHref(path: Path) {
+	return path.isDirectory() ? `${path.name}/` : path.name;
+}
+
+export function getExt(path: Path) {
+	return path.isDirectory() ? "dir" : (path.name.split(".").pop() ?? "");
+}
+
+export function getSize(path: Path) {
+	const file = fs.statSync(path.fullpath());
+	const size = file.isFile() ? file.size : file.isDirectory() ? getDirSize(path.fullpath()) : 0;
+	return bytes(size) ?? "-";
+}
+
+export function getLastModified(path: Path) {
+	const file = fs.statSync(path.fullpath());
+	return file.mtime.toLocaleString();
+}

--- a/src/app/contents/table/index.test.tsx
+++ b/src/app/contents/table/index.test.tsx
@@ -1,0 +1,105 @@
+import fs from "node:fs";
+import { render, screen, within } from "@testing-library/preact";
+import type { Path } from "glob";
+import { beforeEach, describe, expect } from "vitest";
+import type { ContentProps } from "../index";
+import { Table } from "./index";
+
+const mockStatSync = vi.spyOn(fs, "statSync");
+
+describe("Table", () => {
+	beforeEach(() => {
+		mockStatSync.mockClear();
+	});
+
+	const setup = ({ files = [], isRoot = true }: Partial<ContentProps> = {}, stats: Partial<fs.Stats> = {}) => {
+		mockStatSync.mockReturnValue({
+			isFile: () => true,
+			isDirectory: () => false,
+			size: 1024,
+			mtime: new Date("2000-01-01 00:00:00"),
+			...stats,
+		} as fs.Stats);
+
+		return render(<Table files={files} isRoot={isRoot} />);
+	};
+
+	describe("アイテムがファイルの時", () => {
+		beforeEach(() => {
+			const files = [
+				{ name: "file1.txt", fullpath: () => "file1.txt", isDirectory: () => false },
+				{ name: "file2.png", fullpath: () => "file2.png", isDirectory: () => false },
+			] as Path[];
+
+			setup({ files });
+		});
+
+		it("table が表示される", () => {
+			const table = screen.getByRole("table");
+			expect(table).toBeVisible();
+		});
+
+		it("table header が表示される", () => {
+			const rows = screen.getAllByRole("row");
+			// rows + header = 3
+			expect(rows).toHaveLength(3);
+
+			const header = rows[0];
+			expect(header).toBeVisible();
+			expect(header).toHaveTextContent("Name");
+			expect(header).toHaveTextContent("Size");
+			expect(header).toHaveTextContent("Last Modified");
+		});
+
+		it("1つめのファイルが表示される", () => {
+			const firstItem = screen.getAllByRole("row")[1];
+			expect(firstItem).toBeVisible();
+			expect(firstItem).toHaveAttribute("data-name", "file1.txt");
+			expect(firstItem).toHaveAttribute("data-type", "txt");
+			expect(within(firstItem).getByRole("link")).toHaveAttribute("href", "file1.txt");
+			expect(within(firstItem).getByText("1KB")).toBeVisible();
+			expect(within(firstItem).getByText("1/1/2000, 12:00:00 AM")).toBeVisible();
+		});
+
+		it("2つめのファイルが表示される", () => {
+			const secondItem = screen.getAllByRole("row")[2];
+			expect(secondItem).toBeVisible();
+			expect(secondItem).toHaveAttribute("data-name", "file2.png");
+			expect(secondItem).toHaveAttribute("data-type", "png");
+			expect(within(secondItem).getByRole("link")).toHaveAttribute("href", "file2.png");
+			expect(within(secondItem).getByText("1KB")).toBeVisible();
+			expect(within(secondItem).getByText("1/1/2000, 12:00:00 AM")).toBeVisible();
+		});
+	});
+
+	it("アイテムがディレクトリのとき、href と type がディレクトリ用になる", () => {
+		const files = [{ name: "dir", fullpath: () => "dir", isDirectory: () => true }] as Path[];
+		const { getAllByRole } = setup(
+			{ files },
+			{
+				isFile: () => false,
+				isDirectory: () => true,
+			},
+		);
+
+		const dir = getAllByRole("row")[1];
+		expect(dir).toHaveAttribute("data-type", "dir");
+		expect(within(dir).getByRole("link")).toHaveAttribute("href", "dir/");
+	});
+
+	it("isRoot が true のとき、親ディレクトリへのリンクが表示されない", () => {
+		const { getAllByRole } = setup({ isRoot: true });
+
+		const rows = getAllByRole("row");
+		// header only
+		expect(rows).toHaveLength(1);
+	});
+
+	it("isRoot が false のとき、親ディレクトリへのリンクが表示される", () => {
+		const { getAllByRole } = setup({ isRoot: false });
+
+		const parent = getAllByRole("row")[1];
+		expect(parent).toHaveAttribute("data-type", "parent");
+		expect(within(parent).getByRole("link")).toHaveAttribute("href", "../");
+	});
+});

--- a/src/app/contents/table/index.tsx
+++ b/src/app/contents/table/index.tsx
@@ -1,15 +1,8 @@
-import fs from "node:fs";
 import * as core from "@actions/core";
-import bytes from "bytes";
-import type { Path } from "glob";
-import { getDirSize } from "../../utils/directories";
+import type { ContentProps } from "../index";
+import { getExt, getHref, getLastModified, getSize } from "../shared/helper";
 
-export interface P {
-	files: Path[];
-	isRoot: boolean;
-}
-
-export function Table({ files, isRoot }: P) {
+export function Table({ files, isRoot }: ContentProps) {
 	core.debug(`- Generated list: ${files.map((path) => path.name).join(", ")}`);
 	return (
 		<table>
@@ -23,31 +16,17 @@ export function Table({ files, isRoot }: P) {
 			<tbody>
 				{!isRoot && <TableRow href={"../"} name=".." dataAttr={{ "data-type": "parent" }} />}
 				{files.map((path) => (
-					<FileRow key={path.name} path={path} />
+					<TableRow
+						key={path.name}
+						dataAttr={{ "data-type": getExt(path) }}
+						href={getHref(path)}
+						name={path.name}
+						size={getSize(path)}
+						lastModified={getLastModified(path)}
+					/>
 				))}
 			</tbody>
 		</table>
-	);
-}
-
-function FileRow({ path }: { path: Path }) {
-	const file = fs.statSync(path.fullpath());
-
-	const href = file.isDirectory() ? `${path.name}/` : path.name;
-	const ext = file.isDirectory() ? "dir" : (path.name.split(".").pop() ?? "");
-
-	const size = file.isFile() ? file.size : file.isDirectory() ? getDirSize(path.fullpath()) : 0;
-
-	return (
-		<TableRow
-			dataAttr={{
-				"data-type": ext,
-			}}
-			href={href}
-			name={path.name}
-			size={bytes(size) ?? "-"}
-			lastModified={file.mtime.toLocaleString()}
-		/>
 	);
 }
 

--- a/src/assets/global.pcss
+++ b/src/assets/global.pcss
@@ -96,6 +96,21 @@ table {
 	}
 }
 
+ul {
+	padding-left: 1rem;
+
+	a {
+		display: block;
+		margin-left: -2rem;
+		padding: 1rem 1rem 1rem 2rem;
+		border-radius: 4px;
+
+		&:hover {
+			background-color: var(--hover-bg);
+		}
+	}
+}
+
 footer {
 	margin: auto auto 0;
 	padding-top: 1rem;

--- a/src/utils/view-types.test.ts
+++ b/src/utils/view-types.test.ts
@@ -1,9 +1,10 @@
 import { isViewType } from "./view-types";
 
 describe("isViewType", () => {
-	it("TABLE のとき true を返す", () => {
+	it.each(["TABLE", "LIST"])("%s のとき true を返す", () => {
 		expect(isViewType("TABLE")).toBe(true);
 	});
+
 	it("大文字小文字を区別する", () => {
 		expect(isViewType("table")).toBe(false);
 	});

--- a/src/utils/view-types.ts
+++ b/src/utils/view-types.ts
@@ -1,5 +1,6 @@
 export const ViewTypes = {
 	Table: "TABLE",
+	List: "LIST",
 } as const;
 export type ViewTypes = (typeof ViewTypes)[keyof typeof ViewTypes];
 


### PR DESCRIPTION
## Background

ファイルサイズや最終更新が不要な場合がありそう

## Overview

リスト表示形式をサポート

## Testing

- [x] `viewType` が `list` のとき、List モードで表示されること
- [x] `viewType` が `table` のときは、変わらず Table モードで表示されること

## Screenshots or Videos

| Light Theme | Dark Theme |
| --- | --- |
| ![light](https://github.com/user-attachments/assets/7046a514-17d9-49e0-b090-8fa462256088) | ![dark](https://github.com/user-attachments/assets/6b952edd-8d82-4dee-a290-19da264580eb) |
