### PR TITLE
feat: ディレクトリが上に来るようソートしておく

### DIFF
--- a/src/core/generator.test.ts
+++ b/src/core/generator.test.ts
@@ -44,32 +44,4 @@ describe("generate", () => {
 		await setup({ dir, inputs });
 		expect(mockWriteFile).toHaveBeenCalledWith("sandbox/html/index.html", "html", "utf-8");
 	});
-
-	it("ignore が設定されているとき、そのファイル(またはディレクトリ)を無視する", async () => {
-		const dir = { fullpath: () => "sandbox/path" } as Path;
-		const inputs = { ignore: ["**/ignore", "**/to"] } as ActionInputs;
-		await setup({ dir, inputs });
-		expect(mockWriteFile).not.toHaveBeenCalled();
-	});
-
-	it("ignore はルートからの相対パスで動作する", async () => {
-		const dir = { fullpath: () => "sandbox" } as Path;
-		const inputs = { ignore: ["hidden", "html", "path", "theme.css"] } as ActionInputs;
-		await setup({ root: "sandbox", dir, inputs });
-		expect(mockWriteFile).not.toHaveBeenCalled;
-	});
-
-	it("showHiddenFiles が false のとき、隠しファイルを無視する", async () => {
-		const dir = { fullpath: () => "sandbox/hidden" } as Path;
-		const inputs = { showHiddenFiles: false } as ActionInputs;
-		await setup({ dir, inputs });
-		expect(mockWriteFile).not.toHaveBeenCalled();
-	});
-
-	it("showHiddenFiles が true のとき、隠しファイルを表示する", async () => {
-		const dir = { fullpath: () => "sandbox/hidden" } as Path;
-		const inputs = { showHiddenFiles: true } as ActionInputs;
-		await setup({ dir, inputs });
-		expect(mockWriteFile).toHaveBeenCalledWith("sandbox/hidden/index.html", "html", "utf-8");
-	});
 });

--- a/src/core/generator.ts
+++ b/src/core/generator.ts
@@ -2,18 +2,15 @@ import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import * as core from "@actions/core";
 import bytes from "bytes";
-import { type Path, glob } from "glob";
+import type { Path } from "glob";
 import type { ActionInputs } from "src/utils/inputs";
 import color from "../utils/color";
+import { getFiles } from "../utils/files";
 import { truncate } from "../utils/truncate";
 import { renderHTML } from "./html";
 
 export async function generate(root: string, dir: Path, inputs: ActionInputs) {
-	const files = await glob(join(dir.fullpath(), "*"), {
-		ignore: inputs.ignore.map((i) => join(root, i)),
-		dot: inputs.showHiddenFiles,
-		withFileTypes: true,
-	});
+	const files = await getFiles(dir, root, inputs);
 
 	if (files.length === 0) {
 		core.debug(color.yellow(`[Skip] No targets found in: ${dir.fullpath()}`));

--- a/src/utils/files.test.ts
+++ b/src/utils/files.test.ts
@@ -1,0 +1,58 @@
+import type { Path } from "glob";
+import { expect } from "vitest";
+import { getFiles } from "./files";
+import type { ActionInputs } from "./inputs";
+
+describe("getFiles", () => {
+	const setup = ({
+		dir,
+		root,
+		inputs,
+	}: Partial<{
+		dir?: Path;
+		root?: string;
+		inputs?: Partial<Pick<ActionInputs, "ignore" | "showHiddenFiles">>;
+	}> = {}) => getFiles(dir ?? ({} as Path), root ?? "", { ignore: [], ...inputs } as ActionInputs);
+
+	it("ディレクトリ内のすべてのファイル(またはディレクトリ)を取得できソートされている", async () => {
+		const dir = { fullpath: () => "sandbox" } as Path;
+		const files = await setup({ dir });
+		expect(files).toHaveLength(4);
+
+		const expectedFiles = ["hidden", "html", "path", "theme.css"];
+		files.forEach((file, i) => expect(file.name).toBe(expectedFiles[i]));
+	});
+
+	it("ignore が設定されているとき、そのファイル(またはディレクトリ)を無視する", async () => {
+		const dir = { fullpath: () => "sandbox" } as Path;
+		const inputs = { ignore: ["**/hidden"] } as ActionInputs;
+		const files = await setup({ dir, inputs });
+		expect(files).toHaveLength(3);
+
+		const expectedFiles = ["html", "path", "theme.css"];
+		files.forEach((file, i) => expect(file.name).toBe(expectedFiles[i]));
+	});
+
+	it("ignore はルートからの相対パスで動作する", async () => {
+		const root = "sandbox";
+		const dir = { fullpath: () => "sandbox" } as Path;
+		const inputs = { ignore: ["hidden", "html", "path", "theme.css"] } as ActionInputs;
+		const files = await setup({ dir, root, inputs });
+		expect(files).toHaveLength(0);
+	});
+
+	it("showHiddenFiles が false のとき、隠しファイルを無視する", async () => {
+		const dir = { fullpath: () => "sandbox/hidden" } as Path;
+		const inputs = { showHiddenFiles: false } as ActionInputs;
+		const files = await setup({ dir, inputs });
+		expect(files).toHaveLength(0);
+	});
+
+	it("showHiddenFiles が true のとき、隠しファイルを表示する", async () => {
+		const dir = { fullpath: () => "sandbox/hidden" } as Path;
+		const inputs = { showHiddenFiles: true } as ActionInputs;
+		const files = await setup({ dir, inputs });
+		expect(files).toHaveLength(1);
+		expect(files[0].name).toBe(".hidden");
+	});
+});

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -1,0 +1,26 @@
+import { join } from "node:path";
+import { type Path, glob } from "glob";
+import type { ActionInputs } from "./inputs";
+
+export async function getFiles(dir: Path, root: string, inputs: Pick<ActionInputs, "ignore" | "showHiddenFiles">) {
+	const files = await glob(join(dir.fullpath(), "*"), {
+		ignore: inputs.ignore.map((i) => join(root, i)),
+		dot: inputs.showHiddenFiles,
+		withFileTypes: true,
+	});
+
+	return files.sort((a, b) => {
+		const isDirA = a.isDirectory();
+		const isDirB = b.isDirectory();
+
+		if (isDirA && !isDirB) {
+			return -1;
+		}
+
+		if (!isDirA && isDirB) {
+			return 1;
+		}
+
+		return a.name.localeCompare(b.name);
+	});
+}


### PR DESCRIPTION
## Background

#3 によるリクエスト

## Overview

ファイルリストの表示順をソートしておく

## Testing

- [x] ディレクトリが上に来ること
- [x] 名前順でソートされること
- [x] テストパス

## Related

close #5
